### PR TITLE
unboxing + stateAbrvs

### DIFF
--- a/js/build_map.js
+++ b/js/build_map.js
@@ -26,6 +26,7 @@ var waterUseViz = {
     //map: null,
     buttonBox: null
   },
+  stateAbrvs: [], // created in extractNames()
   nationalData: {},
   stateData: {}
 };

--- a/js/map_utils.js
+++ b/js/map_utils.js
@@ -292,7 +292,7 @@ function updateLegendTextToView() {
     
    var state_data = waterUseViz.stateData
       .filter(function(d) { 
-        return d.abrv == activeView; 
+        return d.abrv === activeView; 
     });
     
     waterUseViz.elements

--- a/scripts/process/state_wu_data.R
+++ b/scripts/process/state_wu_data.R
@@ -30,5 +30,5 @@ process.state_wu_data <- function(viz) {
   totals <- sapply(state_data, function(x) x[["use"]]$wateruse[x[["use"]]$category == "total"])
   state_data <- state_data[order(totals, decreasing = FALSE)]
   
-  jsonlite::write_json(state_data, viz[["location"]] )
+  jsonlite::write_json(state_data, viz[["location"]], auto_unbox=TRUE)
 }


### PR DESCRIPTION
I was wrong about stateAbrvs - it does get filled in `extractNames(stateBounds)`, so does need to exist in waterUseViz. Added back in this PR.

For simplifying the json, I think what we need is `auto_unbox=TRUE` in that `write_json()` call:
```r
jsonlite::write_json(state_data, viz[["location"]], auto_unbox=TRUE)
```
which produces
```json
[{"abrv":"DC","open":false,"STATE_NAME":"District of Columbia","use":[{"category":"total","wateruse":0.05},{"category":"thermoelectric","wateruse":0},{"category":"publicsupply","wateruse":0},{"category":"irrigation","wateruse":0.05},{"category":"industrial","wateruse":0}]},
{"abrv":"VT","open":false,"STATE_NAME":"Vermont","use":[{"category":"total","wateruse":90.94},{"category":"thermoelectric","wateruse":0.8},{"category":"publicsupply","wateruse":42.66},{"category":"irrigation","wateruse":3.11},{"category":"industrial","wateruse":10.97}]},
{"abrv":"VI","open":false,"STATE_NAME":"U.S. Virgin Islands","use":[{"category":"total","wateruse":105.27},{"category":"thermoelectric","wateruse":96.66},{"category":"publicsupply","wateruse":4.27},{"category":"irrigation","wateruse":0},{"category":"industrial","wateruse":0.52}]},
{"abrv":"RI","open":false,"STATE_NAME":"Rhode Island","use":[{"category":"total","wateruse":343.24},{"category":"thermoelectric","wateruse":223.03},{"category":"publicsupply","wateruse":97.46},{"category":"irrigation","wateruse":4.25},{"category":"industrial","wateruse":2.08}]},
...]
```
and does indeed allow us to use `===` instead of `==` in the comparison between `d.abrv` and `activeView` in `updateLegendTextToView`.